### PR TITLE
Fix OpenBSD CI by using newer `macos-12` runner.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       run: sudo make install DESTDIR=/usr/gooses; size /usr/gooses/usr/local/bin/sdorfehs
 
   openbsd-build:
-    runs-on: macos-10.15
+    runs-on: macos-12
     steps:
     - name: Bootstrap OpenBSD 7.0
       uses: mario-campos/emulate@v1


### PR DESCRIPTION
The `macos-10.15` runners will soon be unavailable, so time to upgrade!