### PR TITLE
window: add 'winaddcurvscreen' so new windows will start in current vscreen

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -164,6 +164,7 @@ static cmdret *set_winfmt(struct cmdarg **args);
 static cmdret *set_wingravity(struct cmdarg **args);
 static cmdret *set_winliststyle(struct cmdarg **args);
 static cmdret *set_winname(struct cmdarg **args);
+static cmdret *set_winaddcurvscreen(struct cmdarg **args);
 
 /* command function prototypes. */
 static cmdret *cmd_abort(int interactive, struct cmdarg **args);
@@ -349,6 +350,7 @@ init_set_vars(void)
 	add_set_var("wingravity", set_wingravity, 1, "", arg_GRAVITY);
 	add_set_var("winliststyle", set_winliststyle, 1, "", arg_STRING);
 	add_set_var("winname", set_winname, 1, "", arg_STRING);
+	add_set_var("winaddcurvscreen", set_winaddcurvscreen, 1, "", arg_NUMBER);
 }
 
 /*
@@ -4277,6 +4279,21 @@ set_resizefmt(struct cmdarg **args)
 	return cmdret_new(RET_SUCCESS, NULL);
 }
 
+static cmdret *
+set_winaddcurvscreen(struct cmdarg **args)
+{
+	if (args[0] == NULL)
+		return cmdret_new(RET_SUCCESS, "%d",
+		    defaults.win_add_cur_vscreen);
+
+	if (ARG(0, number) < 0 || ARG(0, number) > 1)
+		return cmdret_new(RET_FAILURE,
+		    "winaddcurvscreen: invalid argument");
+
+	defaults.win_add_cur_vscreen = ARG(0, number);
+
+	return cmdret_new(RET_SUCCESS, NULL);
+}
 cmdret *
 cmd_setenv(int interactive, struct cmdarg **args)
 {

--- a/data.h
+++ b/data.h
@@ -350,6 +350,9 @@ struct rp_defaults {
 
 	/* Whether to ignore window size hints */
 	int ignore_resize_hints;
+
+	/* New mapped window always uses current vscreen */
+	int win_add_cur_vscreen;
 };
 
 /* Information about a child process. */

--- a/sdorfehs.1
+++ b/sdorfehs.1
@@ -989,6 +989,14 @@ Specify maximum number of values kept in input history.
 .Pp
 Default is
 .Li 20 .
+.It Cm winaddcurvscreen Li 0 | 1
+When set to
+.Pq Li 1 ,
+new windows will always start in whatever the current vscreen,
+ignoring vscreen of the origin process.
+.Pp
+Default is
+.Li 0 .
 .It Cm ignoreresizehints Li 0 | 1
 When set to
 .Pq Li 1 ,

--- a/sdorfehs.c
+++ b/sdorfehs.c
@@ -226,6 +226,7 @@ init_defaults(void)
 		defaults.vscreens = 12;
 
 	defaults.ignore_resize_hints = 0;
+	defaults.win_add_cur_vscreen = 0;
 }
 
 int

--- a/window.c
+++ b/window.c
@@ -194,7 +194,8 @@ add_to_window_list(rp_screen *s, Window w)
 
 	child_info = get_child_info(w, 1);
 	if (child_info) {
-		if (child_info->vscreen != new_window->vscreen)
+		if (child_info->vscreen != new_window->vscreen &&
+		    !defaults.win_add_cur_vscreen)
 			new_window->vscreen = child_info->vscreen;
 
 		if (!child_info->window_mapped) {


### PR DESCRIPTION
Add boolean rcvar `winaddcurvscreen` (default 0).

This adds a variable to let new windows get spawned in the current vscreen, if they would otherwise be spawned in a different one because of their parent having been started therein.  This allows for `urxvtc` terminal windows (in client mode) to behave as expected and start in the current vscreen, while not altering the default behavior.

Fixes #37