### PR TITLE
partial support for group-like vscreens (vnext, vprev, vother, named moves)

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -2711,7 +2711,7 @@ command(int interactive, char *data)
 				goto free_lists;
 			} else if (list_size(&head) > uc->num_args) {
 				result = cmdret_new(RET_FAILURE,
-				    "too many arguments.");
+				    "command: too many arguments.");
 				goto free_lists;
 			} else {
 				struct cmdarg **cmdargs = arg_array(&args);
@@ -5278,7 +5278,7 @@ cmd_set(int interactive, struct cmdarg **args)
 		result = cmdret_new(RET_FAILURE, "not enough arguments.");
 		goto failed;
 	} else if (list_size(&head) > ARG(0, variable)->nargs) {
-		result = cmdret_new(RET_FAILURE, "too many arguments.");
+		result = cmdret_new(RET_FAILURE, "cmd_set: too many args.");
 		goto failed;
 	}
 

--- a/actions.c
+++ b/actions.c
@@ -2121,6 +2121,10 @@ find_vscreen(char *str)
 	rp_vscreen *vscreen;
 	int n;
 
+	/* Exact matches are special cases. */
+	if ((vscreen = screen_find_vscreen_by_name(rp_current_screen, str, 1)))
+		return vscreen;
+
 	/* Check if the user typed a vsceen number. */
 	n = string_to_positive_int(str);
 	if (n >= 0) {
@@ -2128,10 +2132,6 @@ find_vscreen(char *str)
 		if (vscreen)
 			return vscreen;
 	}
-
-	/* Exact matches are special cases. */
-	if ((vscreen = screen_find_vscreen_by_name(rp_current_screen, str, 1)))
-		return vscreen;
 
 	vscreen = screen_find_vscreen_by_name(rp_current_screen, str, 0);
 	return vscreen;

--- a/actions.c
+++ b/actions.c
@@ -264,6 +264,9 @@ static cmdret *cmd_vsplit(int interactive, struct cmdarg **args);
 static cmdret *cmd_verbexec(int interactive, struct cmdarg **args);
 static cmdret *cmd_version(int interactive, struct cmdarg **args);
 static cmdret *cmd_vmove(int interactive, struct cmdarg **args);
+static cmdret *cmd_vnext(int interactive, struct cmdarg **args);
+static cmdret *cmd_vother(int interactive, struct cmdarg **args);
+static cmdret *cmd_vprev(int interactive, struct cmdarg **args);
 static cmdret *cmd_vrename(int interactive, struct cmdarg **args);
 static cmdret *cmd_vscreens(int interactive, struct cmdarg **args);
 static cmdret *cmd_vselect(int interactive, struct cmdarg **args);
@@ -559,6 +562,9 @@ init_user_commands(void)
 	add_command("version",		cmd_version,	0, 0, 0);
 	add_command("vmove",		cmd_vmove,	1, 1, 1,
 	            "Virtual Screen: ", arg_VSCREEN);
+	add_command("vnext",		cmd_vnext,	0, 0, 0);
+	add_command("vother",		cmd_vother,	0, 0, 0);
+	add_command("vprev",		cmd_vprev,	0, 0, 0);
 	add_command("vrename",		cmd_vrename,	1, 1, 1,
 	            "Change virtual screen name to: ", arg_REST);
 	add_command("vscreens",		cmd_vscreens,	0, 0, 0);
@@ -5016,6 +5022,43 @@ cmd_vscreens(int interactive, struct cmdarg **args)
 		sbuf_free(vscreen_list);
 		return ret;
 	}
+}
+
+cmdret *
+cmd_vnext(int interactive, struct cmdarg **args)
+{
+	rp_vscreen *v;
+	v = vscreen_next_vscreen(rp_current_vscreen);
+	if (!v)
+		return cmdret_new(RET_FAILURE, "%s", "next vscreen failed");
+
+	set_current_vscreen(v);
+	return cmdret_new(RET_SUCCESS, NULL);
+}
+
+cmdret *
+cmd_vprev(int interactive, struct cmdarg **args)
+{
+	rp_vscreen *v;
+	v = vscreen_prev_vscreen(rp_current_vscreen);
+	if (!v)
+		return cmdret_new(RET_FAILURE, "%s", "prev vscreen failed");
+
+	set_current_vscreen(v);
+	return cmdret_new(RET_SUCCESS, NULL);
+}
+
+cmdret *
+cmd_vother(int interactive, struct cmdarg **args)
+{
+	rp_vscreen *v;
+	v = screen_last_vscreen(rp_current_screen);
+	if (!v)
+		/* todo: should we just return success here so it's a no-op? */
+		return cmdret_new(RET_FAILURE, "%s", "last vscreen failed");
+
+	set_current_vscreen(v);
+	return cmdret_new(RET_SUCCESS, NULL);
 }
 
 cmdret *

--- a/actions.c
+++ b/actions.c
@@ -5735,23 +5735,17 @@ cmd_vmove(int interactive, struct cmdarg **args)
 {
 	rp_vscreen *v;
 	rp_window *w;
-	int n;
 
 	if ((w = current_window()) == NULL)
 		return cmdret_new(RET_FAILURE, "vmove: no focused window");
 
-	n = string_to_positive_int(ARG_STRING(0));
-	if (n >= 0) {
-		v = screen_find_vscreen_by_number(rp_current_screen, n);
-		if (v) {
-			vscreen_move_window(v, w);
-			set_current_vscreen(v);
-			set_active_window(w);
-			return cmdret_new(RET_SUCCESS, NULL);
-		}
-	}
+	if (!(v = find_vscreen(ARG_STRING(0))))
+		return cmdret_new(RET_FAILURE, "vmove: invalid vscreen");
 
-	return cmdret_new(RET_FAILURE, "vmove: invalid virtual screen");
+	vscreen_move_window(v, w);
+	set_current_vscreen(v);
+	set_active_window(w);
+	return cmdret_new(RET_SUCCESS, NULL);
 }
 
 cmdret *

--- a/sdorfehs.1
+++ b/sdorfehs.1
@@ -745,7 +745,13 @@ Output version and compile time information.
 .It Ic vmove Oo Ar vscreen Oc
 Move the current window to the current frame on vscreen
 .Ar vscreen
-and switch to it.
+and switch to it.  Specify by either name or number.
+.It Ic vnext
+Switch to next vscreen.
+.It Ic vother
+Switch to the last-accessed vscreen before the current one.
+.It Ic vprev
+Switch to previous vscreen.
 .It Ic vrename
 Rename current vscreen.
 .It Ic vscreens


### PR DESCRIPTION
this restores some functionality from groups, that are missing from vscreens:

  - ties in the vnext, vprev, and vother functions that were in the code but not linked to actual accessible commands.
  - allows the windows to be moved to by name
  - looks windows up by name first instead of number

Fixes #40