### PR TITLE
support applications that try to raise windows via _NET_ACTIVE_WINDOW

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -3601,10 +3601,11 @@ set_rudeness(struct cmdarg **args)
 		    rp_honour_transient_raise |
 		    (rp_honour_normal_raise << 1) |
 		    (rp_honour_transient_map << 2) |
-		    (rp_honour_normal_map << 3));
+		    (rp_honour_normal_map << 3) |
+		    (rp_honour_vscreen_switch << 4));
 
 	num = ARG(0, number);
-	if (num < 0 || num > 15)
+	if (num < 0 || num > 31)
 		return cmdret_new(RET_FAILURE, "rudeness: invalid level '%s'",
 		    ARG_STRING(0));
 
@@ -3612,6 +3613,7 @@ set_rudeness(struct cmdarg **args)
 	rp_honour_normal_raise = num & 2 ? 1 : 0;
 	rp_honour_transient_map = num & 4 ? 1 : 0;
 	rp_honour_normal_map = num & 8 ? 1 : 0;
+	rp_honour_vscreen_switch = num & 16 ? 1 : 0;
 
 	return cmdret_new(RET_SUCCESS, NULL);
 }

--- a/events.c
+++ b/events.c
@@ -146,21 +146,21 @@ unmap_notify(XEvent *ev)
 }
 
 static void
-map_request(XEvent *ev)
+map_request(Window window)
 {
 	rp_window *win;
 
-	win = find_window(ev->xmap.window);
+	win = find_window(window);
 	if (win == NULL) {
 		PRINT_DEBUG(("Map request from an unknown window.\n"));
-		XMapWindow(dpy, ev->xmap.window);
+		XMapWindow(dpy, window);
 		return;
 	}
 
-	if (unmanaged_window(ev->xmap.window)) {
+	if (unmanaged_window(window)) {
 		PRINT_DEBUG(("Map request from an unmanaged window\n"));
 		unmanage(win);
-		XMapRaised(dpy, ev->xmap.window);
+		XMapRaised(dpy, window);
 		return;
 	}
 
@@ -432,13 +432,7 @@ client_msg(XClientMessageEvent *ev)
 		}
 	} else if (win && ev->message_type == _net_active_window) {
 		PRINT_DEBUG(("_NET_ACTIVE_WINDOW raise: 0x%lx\n", win->w));
-		rp_window *w = find_window(win->w);
-		if (w == NULL) {
-			PRINT_DEBUG(("no _NET_ACTIVE_WINDOW 0x%lx\n", win->w));
-			return;
-		}
-		set_current_vscreen(w->vscreen);
-		set_active_window(w);
+		map_request(win->w);
 	} else {
 		PRINT_DEBUG(("unknown client message type 0x%lx\n",
 		    ev->message_type));
@@ -765,7 +759,7 @@ delegate_event(XEvent *ev)
 
 	case MapRequest:
 		PRINT_DEBUG(("--- Handling MapRequest ---\n"));
-		map_request(ev);
+		map_request(ev->xmap.window);
 		break;
 
 	case KeyPress:

--- a/events.c
+++ b/events.c
@@ -182,24 +182,26 @@ map_request(Window window)
 		PRINT_DEBUG(("Mapping Iconic window\n"));
 
 		if (win->vscreen != rp_current_vscreen) {
-			/*
-			 * It is always rude to raise a window in another
-			 * vscreen
-			 */
-			show_rudeness_msg(win, 1);
-			break;
+			if (!rp_honour_vscreen_switch) {
+				show_rudeness_msg(win, 1);
+				break;
+			}
+			PRINT_DEBUG(("honouring raise from other vscreen\n"));
 		}
 
 		/* Depending on the rudeness level, actually map the window. */
 		if (win->last_access == 0) {
 			if ((rp_honour_transient_map && win->transient)
-			    || (rp_honour_normal_map && !win->transient))
+			    || (rp_honour_normal_map && !win->transient)) {
+				set_current_vscreen(win->vscreen);
 				set_active_window(win);
+			}
 		} else {
 			if ((rp_honour_transient_raise && win->transient)
-			    || (rp_honour_normal_raise && !win->transient))
+			    || (rp_honour_normal_raise && !win->transient)) {
+				set_current_vscreen(win->vscreen);
 				set_active_window(win);
-			else
+			} else
 				show_rudeness_msg(win, 1);
 		}
 		break;

--- a/events.c
+++ b/events.c
@@ -430,6 +430,15 @@ client_msg(XClientMessageEvent *ev)
 			else
 				window_full_screen(NULL);
 		}
+	} else if (win && ev->message_type == _net_active_window) {
+		PRINT_DEBUG(("_NET_ACTIVE_WINDOW raise: 0x%lx\n", win->w));
+		rp_window *w = find_window(win->w);
+		if (w == NULL) {
+			PRINT_DEBUG(("no _NET_ACTIVE_WINDOW 0x%lx\n", win->w));
+			return;
+		}
+		set_current_vscreen(w->vscreen);
+		set_active_window(w);
 	} else {
 		PRINT_DEBUG(("unknown client message type 0x%lx\n",
 		    ev->message_type));

--- a/globals.c
+++ b/globals.c
@@ -107,6 +107,7 @@ int rp_honour_transient_raise = 1;
 int rp_honour_normal_raise = 1;
 int rp_honour_transient_map = 1;
 int rp_honour_normal_map = 1;
+int rp_honour_vscreen_switch = 0;
 
 char *rp_error_msg = NULL;
 

--- a/globals.h
+++ b/globals.h
@@ -163,6 +163,7 @@ extern int rp_honour_transient_raise;
 extern int rp_honour_normal_raise;
 extern int rp_honour_transient_map;
 extern int rp_honour_normal_map;
+extern int rp_honour_vscreen_switch;
 
 /* Keep track of X11 error messages. */
 extern char *rp_error_msg;

--- a/sdorfehs.1
+++ b/sdorfehs.1
@@ -1104,9 +1104,11 @@ Normal windows may raise.
 New transient windows end up in the foreground.
 .It 8
 New normal windows end up in the foreground.
+.It 16
+Window raise from different vscreen will be permitted.
 .El
 .Pp
-Default is all allowed i.e.\& 15.
+Default is all allowed except vscreen switch, i.e.\& 15.
 .It Cm startupmessage Li 0 | 1
 Decide whether to show a greeting message at startup.
 .Pp


### PR DESCRIPTION
Chrome, possibly others that expect/use EWMH are trying to raise [their own] windows with ClientMessage XEvents, which are not handled by *sdorfehs*.  Sdorfehs sets `_NET_ACTIVE_WINDOW` but does not respond to `ClientMessage` which makes requests with it.

This patch implements switching to the thus-requested window by submitting to `find_window()`, which seems purpose-built for it...

Update: we also add a new 'rudeness' bit (decimal 16) that allows the window requesting the raise to switch vscreens.  The default before (and still) was never to allow this, but with this bit, it can be overridden and will be allowed.

This restores Chrome window switch in tab search dialog (upper right or Ctrl-Shift-A)

Fixes #35