### PR TITLE
support larger than 1k client responses (bigger winfmts, etc)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,9 @@ LDFLAGS+=	`pkg-config --libs ${PKGLIBS}`
 
 # uncomment to enable debugging
 #CFLAGS+=	-g -DDEBUG=1
-# and this for input-specific debugging
+# and this for subsystem-specific debugging
 #CFLAGS+=	-DINPUT_DEBUG=1
+#CFLAGS+=	-DSENDCMD_DEBUG=1
 
 BINDIR=		${DESTDIR}$(PREFIX)/bin
 MANDIR=		${DESTDIR}$(PREFIX)/man/man1

--- a/sdorfehs.h
+++ b/sdorfehs.h
@@ -50,6 +50,16 @@ do {                                            \
 #define PRINT_DEBUG(fmt) do {} while (0)
 #endif	/* DEBUG */
 
+#ifdef SENDCMD_DEBUG
+#define WARNX_DEBUG(fmt, ...)                   \
+do {                                            \
+  fprintf (stderr, fmt, __VA_ARGS__);           \
+  fflush (stderr);                              \
+} while (0)
+#else
+#define WARNX_DEBUG(fmt, ...) do {} while (0)
+#endif	/* SENDCMD_DEBUG */
+
 #ifdef INPUT_DEBUG
 #define PRINT_INPUT_DEBUG(fmt)                  \
 do {                                            \


### PR DESCRIPTION
Previously the buffer size could not exceed 1k in the response from server, or it would be truncated.  This included commands like, for example:

```
$ windows w %{i,a,c,t,n}
```

would easily get over 1024 chars (actually 1022 due to \n and \0) on my system.  The new code can handle any size response.

Fixes #39