### PR TITLE
implement fallback to more reliable XResQueryClientIds() if no _NET_WM_PID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: install dependencies
-      run: sudo apt-get install -y libx11-dev libxft-dev libxrandr-dev libxtst-dev
+      run: sudo apt-get install -y libx11-dev libxft-dev libxrandr-dev libxtst-dev libxres-dev
     - name: install clang-tools for make regress
       run: sudo apt-get install -y clang-tools
     - name: make

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VERSION!=	[ -d .git ] && \
 
 CC?=		cc
 PREFIX?=	/usr/local
-PKGLIBS=	x11 xft xrandr xtst
+PKGLIBS=	x11 xft xrandr xtst xres
 CFLAGS+=	-O2 -Wall \
 		-Wunused -Wmissing-prototypes -Wstrict-prototypes -Wunused \
 		`pkg-config --cflags ${PKGLIBS}` \

--- a/sdorfehs.h
+++ b/sdorfehs.h
@@ -27,6 +27,8 @@
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 #include <X11/Xlocale.h>
+#include <X11/Xmd.h>
+#include <X11/extensions/XRes.h>
 #include <fcntl.h>
 
 #if defined(__BASE_FILE__)

--- a/window.c
+++ b/window.c
@@ -112,25 +112,28 @@ window_name(rp_window *win)
 struct rp_child_info *
 get_child_info(Window w, int add)
 {
+	XResClientIdSpec specs;
+	XResClientIdValue *results = NULL;
 	rp_child_info *cur;
 	unsigned long pid = 0;
+	long nresults;
+	int i;
 
 	if (!get_atom(w, _net_wm_pid, XA_CARDINAL, 0, &pid, 1, NULL)) {
 		PRINT_DEBUG(("Couldn't get _NET_WM_PID Property\n"));
-		long nresults;
-		XResClientIdValue *results = NULL;
-		XResClientIdSpec specs;
 		specs.client = w;
 		specs.mask = XRES_CLIENT_ID_PID_MASK;
-		if (XResQueryClientIds(dpy, 1, &specs, &nresults, &results) != Success)
+		if (XResQueryClientIds(dpy, 1, &specs, &nresults,
+		    &results) != Success)
 			pid = 0;
 		else {
-			int i;
 			for (i = 0; i < nresults; i++) {
-				if (results[i].spec.mask == XRES_CLIENT_ID_PID_MASK) {
-					pid = *(unsigned long *)(results[i].value);
-					break;
-				}
+				if (results[i].spec.mask !=
+				    XRES_CLIENT_ID_PID_MASK)
+					continue;
+
+				pid = *(unsigned long *)(results[i].value);
+				break;
 			}
 			XFree(results);
 		}


### PR DESCRIPTION
`get_child_info()` relies on `_NET_WM_PID` to look up new windows.  This has [at least] two caveats:

- the program must be conforming and always set its own `_NET_WM_PID`, which is entirely voluntary and many programs do not
- it must set `_NET_WM_PID` before the window manager receives the `CreateNotify` event and tries to look up the window

This race is frequently failing for some applications, like with `st` for me.  So instead, this patch falls back to the newer `XResQueryClientIds()` which relies on pid data maintained by the X server and available by XRes extensions in `-lXRes`.

We still use `_NET_WM_PID` first if it's available to retain old behavior; this only augments if no such atom is found.  This allows for setting different PID than actual, which some programs do that have a "manager" process.

This patch require libXRes 1.2+ and headers to be present on the system.  On my system this means `libxres-dev` and `libxres1` packages.  1.2 was released 5 years ago and should be on most modern-ish systems.  If anyone uses this patch and they don't have it available, I can add some kind of ifdef or something, but there's currently no autoconf so this is only manually selectable and I thought more people would have this library available than not...

Fixes #46