### PR TITLE
implement cmd_execw, an 'exec' that waits for forked proc to exit

### DIFF
--- a/actions.c
+++ b/actions.c
@@ -194,6 +194,7 @@ static cmdret *cmd_exchangeup(int interactive, struct cmdarg **args);
 static cmdret *cmd_exec(int interactive, struct cmdarg **args);
 static cmdret *cmd_execa(int interactive, struct cmdarg **args);
 static cmdret *cmd_execf(int interactive, struct cmdarg **args);
+static cmdret *cmd_execw(int interactive, struct cmdarg **args);
 static cmdret *cmd_fdump(int interactive, struct cmdarg **args);
 static cmdret *cmd_focusdown(int interactive, struct cmdarg **args);
 static cmdret *cmd_focuslast(int interactive, struct cmdarg **args);
@@ -444,6 +445,8 @@ init_user_commands(void)
 	            "/bin/sh -c ", arg_SHELLCMD);
 	add_command("execf",		cmd_execf,	2, 2, 2,
 	            "frame to execute in:", arg_FRAME,
+	            "/bin/sh -c ", arg_SHELLCMD);
+	add_command("execw",		cmd_execw,	1, 1, 1,
 	            "/bin/sh -c ", arg_SHELLCMD);
 	add_command("fdump",		cmd_fdump,	1, 0, 0,
 	            "", arg_NUMBER);
@@ -2767,6 +2770,18 @@ cmd_exec(int interactive, struct cmdarg **args)
 {
 	spawn(ARG_STRING(0), current_frame(rp_current_vscreen));
 	return cmdret_new(RET_SUCCESS, NULL);
+}
+
+cmdret *
+cmd_execw(int interactive, struct cmdarg **args)
+{
+	int status = -1;
+	pid_t pid = spawn(ARG_STRING(0), current_frame(rp_current_vscreen));
+	if (waitpid(pid, &status, 0) == -1)
+		perror("cmd_execw");
+	else
+		status = WEXITSTATUS(status);
+	return cmdret_new(status == 0? RET_SUCCESS: RET_FAILURE, NULL);
 }
 
 cmdret *

--- a/sdorfehs.1
+++ b/sdorfehs.1
@@ -343,6 +343,18 @@ Spawn a shell executing
 .Ar shell\-command ,
 showing _NET_WM_PID supporting programs in the given frame instead of
 the frame selected when this program is run.
+.It Ic execw Ar shell\-command
+Spawn a shell executing
+.Ar shell\-command ,
+but wait for it to finish.  This should behave the same as
+.Ar exec
+but will wait for completion.  Use timeout(1) if it might hang, or
+.Nm
+will hang itself waiting for completion.  Use the 'exec' shell builtin as the
+first word in the command string to get similar behavior to
+.Ar execa
+owing to the forked pid remaining stable and known to
+.Nm .
 .It Ic fdump Op Ar screenno
 Output the defining data for all frames of the current screen, or
 for screen number


### PR DESCRIPTION
This patch implements a synchronous `execw` command, which will allow external commands to be sequenced in the rcfile.

It relies on the user to manage hangs themselves (eg with `timeout(1)`), and this is mentioned in man page update.

Fixes #48