### PR TITLE
implement a new 'execv' command to spawn window in particular vscreen

### DIFF
--- a/actions.h
+++ b/actions.h
@@ -44,5 +44,6 @@ char *wingravity_to_string(int g);
 rp_action *find_keybinding(KeySym keysym, unsigned int state, rp_keymap *map);
 rp_action *find_keybinding_by_action(char *action, rp_keymap *map);
 int spawn(char *cmd, rp_frame *frame);
+int vspawn(char *cmd, rp_frame *frame, rp_vscreen *vscreen);
 
 #endif	/* ! _SDORFEHS_ACTIONS_H */

--- a/sdorfehs.1
+++ b/sdorfehs.1
@@ -343,6 +343,13 @@ Spawn a shell executing
 .Ar shell\-command ,
 showing _NET_WM_PID supporting programs in the given frame instead of
 the frame selected when this program is run.
+.It Ic execv Ar vscreen shell\-command
+Spawn a shell within a specific vscreen
+.Ar vscreen ,
+executing
+.Ar shell\-command
+as in the 'exec' command (i.e., using "sh -c").  This is not likely to work
+well with 'winaddcurvscreen' set to 1 anywhere in the configuration file.
 .It Ic execw Ar shell\-command
 Spawn a shell executing
 .Ar shell\-command ,


### PR DESCRIPTION
This patch adds an `execv` command that takes an initial argument to specify the vscreen for the new window.  Existing `exec` family of commands will have unchanged behavior.  This allows for setting up initial windows in different vscreens, in order to have a reproducible set of initial windows each time `sdorfehs` is started.

This still won't force the window of an unknown process (such as spawned by `urxvtc`) in a certain vscreen, because the vscreen info is stored in child proc, which, once mapped, is looked up by pid.

Using `execv` is currently incompatible with `winvcur` (from https://github.com/jcs/sdorfehs/pull/38) set to 1.

Fixes #50