### PR TITLE
format: handle zero size hints

### DIFF
--- a/format.c
+++ b/format.c
@@ -221,7 +221,8 @@ fmt_incheight(rp_window_elem *elem, struct sbuf *buf)
 	int height;
 	height = elem->win->height;
 
-	if (elem->win->hints->flags & PResizeInc)
+	if ((elem->win->hints->flags & PResizeInc) &&
+	    elem->win->hints->height_inc > 0)
 		height /= elem->win->hints->height_inc;
 
 	sbuf_printf_concat(buf, "%d", height);
@@ -233,7 +234,8 @@ fmt_incwidth(rp_window_elem *elem, struct sbuf *buf)
 	int width;
 	width = elem->win->width;
 
-	if (elem->win->hints->flags & PResizeInc)
+	if ((elem->win->hints->flags & PResizeInc) &&
+	    elem->win->hints->width_inc > 0)
 		width /= elem->win->hints->width_inc;
 
 	sbuf_printf_concat(buf, "%d", width);


### PR DESCRIPTION
(At least) GNOME Terminal sometimes has a zero in `width_inc` and `height_inc` in XSizeHints. This PR adds a check to avoid divide by zero which was killing sdorfehs with `SIGFPE`.

To reproduce the crash:
- Open GNOME Terminal in an empty vscreen
- Fullscreen with F11
- Switch to a different vscreen and switch back
- GNOME Terminal is no longer fullscreen but (for reasons I don't understand) its size hints are not updated
- Create a horizontal split
- Divide by zero error in `fmt_incheight` and (if `fmt_incheight` is patched) in `fmt_incwidth`

I think that I've experienced this with other apps which lose fullscreen after changing vscreen, but can definitely reproduce at will with GNOME Terminal.

(Also: thanks for sdorfehs, it's great to have a WM that suits how I want to use a computer!)