### PR TITLE
Quiet -fsanitize=undefined warning, not an actual error.

### DIFF
--- a/communications.c
+++ b/communications.c
@@ -61,6 +61,7 @@ listen_for_commands(void)
 
 	strncpy(sun.sun_path, rp_glob_screen.control_socket_path,
 	    sizeof(sun.sun_path)-1);
+	sun.sun_path[sizeof(sun.sun_path) - 1] = '\0';
 	sun.sun_family = AF_UNIX;
 
 	if (unlink(rp_glob_screen.control_socket_path) == -1 &&
@@ -114,6 +115,7 @@ send_command(int interactive, unsigned char *cmd)
 
 	strncpy(sun.sun_path, rp_glob_screen.control_socket_path,
 	    sizeof(sun.sun_path)-1);
+	sun.sun_path[sizeof(sun.sun_path) - 1] = '\0';
 	sun.sun_family = AF_UNIX;
 
 	if (connect(fd, (struct sockaddr *)&sun, sizeof(sun)) == -1)

--- a/communications.c
+++ b/communications.c
@@ -60,7 +60,7 @@ listen_for_commands(void)
 		    rp_glob_screen.control_socket_path);
 
 	strncpy(sun.sun_path, rp_glob_screen.control_socket_path,
-	    sizeof(sun.sun_path));
+	    sizeof(sun.sun_path)-1);
 	sun.sun_family = AF_UNIX;
 
 	if (unlink(rp_glob_screen.control_socket_path) == -1 &&
@@ -113,7 +113,7 @@ send_command(int interactive, unsigned char *cmd)
 		    rp_glob_screen.control_socket_path);
 
 	strncpy(sun.sun_path, rp_glob_screen.control_socket_path,
-	    sizeof(sun.sun_path));
+	    sizeof(sun.sun_path)-1);
 	sun.sun_family = AF_UNIX;
 
 	if (connect(fd, (struct sockaddr *)&sun, sizeof(sun)) == -1)


### PR DESCRIPTION
Not sure if you will want to apply this one, but for some reason gcc 12.2.1 seems to not notice this is ok when using -fsanitize=undefined.