### PR TITLE
fix making one too many "vscreens" in extend case

### DIFF
--- a/vscreen.c
+++ b/vscreen.c
@@ -125,7 +125,7 @@ vscreens_resize(int n)
 		}
 	} else if (n > defaults.vscreens) {
 		list_for_each_entry(scr, &rp_screens, node) {
-			for (x = defaults.vscreens; x <= n; x++) {
+			for (x = defaults.vscreens; x < n; x++) {
 				cur = xmalloc(sizeof(rp_vscreen));
 				init_vscreen(cur, scr);
 				list_add_tail(&cur->node, &scr->vscreens);


### PR DESCRIPTION
The extend code keeps counting by N but N is a count, not an index.  Index numbers should be considered as shifted by one from count numbers.  Result is growing (requested "vscreens" value larger than currently configured one) will end up making one too many.  Shrinking already works correctly.