### PR TITLE
communications.c: Added support for messages spanning multiple lines.

### DIFF
--- a/communications.c
+++ b/communications.c
@@ -190,8 +190,8 @@ receive_command(void)
 		}
 
 		if (read(cl, &c, 1) == 1) {
-			if (c == '\n') {
-				cmd[len++] = '\0';
+			if ((c == '\0') && (len > 0)) {
+				cmd[len - 1] = '\0';
 				break;
 			}
 			cmd[len++] = c;


### PR DESCRIPTION
Changed receive_command() to read from the socket until the second occurrence  of '\0' instead of waiting for the first \n, which previously made multi-line messages impossible. Now, messages containing '\0' will be truncated.

I would recommend to change the way this function reads from the socket; instead of reading one byte at a time, make the second and third byte sent to the socket by the server to be the size of the message. Then, the client determines the size it will need to parse and then either loop until the whole message has been read or read the entire message at once. I don't know enough C to implement this, but it would prevent from making so many read() calls as well as checking if len == sizeof(cmd) as many times as the size of the message.