### PR TITLE
make control socket more robust and support larger messages

### DIFF
--- a/communications.c
+++ b/communications.c
@@ -52,7 +52,7 @@ listen_for_commands(void)
 	struct sockaddr_un sun;
 
 	if ((rp_glob_screen.control_socket_fd = socket(AF_UNIX,
-	    SOCK_STREAM | SOCK_NONBLOCK, 0)) == -1)
+	    SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0)) == -1)
 		err(1, "socket");
 
 	if (strlen(rp_glob_screen.control_socket_path) >= sizeof(sun.sun_path))
@@ -263,6 +263,11 @@ receive_command(void)
 
 	if ((cl = accept(rp_glob_screen.control_socket_fd, NULL, NULL)) == -1) {
 		warn("accept");
+		return;
+	}
+	if ((fcntl(cl, F_SETFD, FD_CLOEXEC)) == -1) {
+		warn("cloexec");
+		close(cl);
 		return;
 	}
 

--- a/communications.c
+++ b/communications.c
@@ -83,7 +83,7 @@ listen_for_commands(void)
 }
 
 int
-send_command(int interactive, unsigned char *cmd)
+send_command(int interactive, char *cmd)
 {
 	struct sockaddr_un sun;
 	char *wcmd, *bufstart;
@@ -101,7 +101,7 @@ send_command(int interactive, unsigned char *cmd)
 #endif
 	WARNX_DEBUG("%s: enter\n", dpfx);
 
-	len = 1 + strlen((char *)cmd) + 2;
+	len = 1 + strlen(cmd) + 2;
 	wcmd = malloc(len);
 	if (snprintf(wcmd, len, "%c%s\n", interactive, cmd) != (len - 1))
 		errx(1, "snprintf");

--- a/communications.c
+++ b/communications.c
@@ -211,8 +211,7 @@ void
 receive_command(void)
 {
 	cmdret *cmd_ret;
-	char cmd[BUFSZ] = { 0 }, c;
-	char *result, *rcmd;
+	char *result, *rcmd, *cmd;
 	int cl, len = 0, interactive = 0;
 
 	PRINT_DEBUG(("have connection waiting on command socket\n"));
@@ -222,24 +221,12 @@ receive_command(void)
 		return;
 	}
 
-	while (len <= sizeof(cmd)) {
-		if (len == sizeof(cmd)) {
-			warn("%s: bogus command length", __func__);
-			close(cl);
-			return;
-		}
-
-		if (read(cl, &c, 1) == 1) {
-			cmd[len] = c;
-			if (len++ && c == '\0')
-				break;
-		} else if (errno != EAGAIN) {
-			PRINT_DEBUG(("bad read result on control socket: %s\n",
-			    strerror(errno)));
-			break;
-		}
+	len = recv_unix(cl, &cmd)
+	if (cmd[len] != '\0') {
+		/* should not be possible, TODO remove */
+		warnx("%s\n", "last byte of sent command not null");
+		cmd[len] = '\0';
 	}
-
 	interactive = cmd[0];
 	rcmd = cmd + 1;
 
@@ -267,5 +254,6 @@ receive_command(void)
 
 	PRINT_DEBUG(("receive_command: write finished, closing\n"));
 
+	free(cmd);
 	close(cl);
 }

--- a/communications.h
+++ b/communications.h
@@ -22,7 +22,7 @@
 
 void init_control_socket_path(void);
 void listen_for_commands(void);
-int send_command(int interactive, unsigned char *cmd);
+int send_command(int interactive, char *cmd);
 void receive_command(void);
 
 #endif	/* ! _SDORFEHS_COMMUNICATIONS_H */

--- a/sdorfehs.c
+++ b/sdorfehs.c
@@ -303,7 +303,7 @@ main(int argc, char *argv[])
 		int j, exit_status = 0;
 
 		for (j = 0; j < cmd_count; j++) {
-			if (!send_command(interactive, (unsigned char *)cmd[j]))
+			if (!send_command(interactive, cmd[j]))
 				exit_status = 1;
 			free(cmd[j]);
 		}


### PR DESCRIPTION
This patch series makes a number of changes in `communications.c` to make sending and receiving of messages on the unix control socket more robust against failures and transient conditions.  It also removes limitations on the content and size of the messages.

Previously, the control socket was augmented in #43 to extend the size of response that could be sent by `receive_message()` back to the sender -- ie to `send_message()` -- which was awaiting response to queries, or output from executed commands.  This handled the case where there was a large output (eg, `sdorfehs -c windows`), but did not cover the case of large input messages, as noted in #66.

Included in this PR are patches which factor out the earlier code from #43 into a common function which is now shared by both the receiver (getting a command) and the sender (getting the response, after sending the command).  The message buffer is now gathered on the heap and processed whole, rather than one byte at a time.  We also cover partial reads, and interrupted reads, which can happen when an [asynchronously] forked child process (such as with sdorfehs' `exec` command) happens to finish during message processing, and the `SIGCHLD` handler interrupts message IO system calls.  Error handling is made somewhat more robust as a side effect.

There was already existing code to process multi-line messages for `sdorfehs -c echo` command: it would draw a window that was sized according to the presence of newlines.  However, the message receive code had been changed to use a newline as message delimiter ever since `sdorfehs` was augmented to use a UNIX domain socket (noted in #66).  That limitation is now removed, and we go until the end of the submitted buffer.  This is safe because:

- we will keep getting bytes until the socket is closed or `EWOULDBLOCK` (ie `EAGAIN`), so we know the message is either still proceeding or finished
- these bytes originated as C strings (such as `sdorfehs -c` coming from the argument vector), which we know are NULL terminated, and have taken care to include trailing NULL in the message
- we keep reading until we got everything, or discard and cancel
- we zero all the bytes in our buffers as we grow it, before writing into it
- we have a safety check that the last byte in the message is indeed a NULL (this can be removed later)

Now we can do things like:
```
sdorfehs -c "echo $(ncal 2024)"
```
which extends into 3 message quanta (via `realloc()`).  It works well in testing.

Lastly, we also fixed a stray leak of the control socket FD.  All forked procs  (such as terminals) were getting a copy of the FD due to UNIX semantics preserving open file descriptors across `execv()`.
