### PR TITLE
stop accidental leakage of /dev/null fd to child procs

### DIFF
--- a/sdorfehs.c
+++ b/sdorfehs.c
@@ -232,7 +232,7 @@ init_defaults(void)
 int
 main(int argc, char *argv[])
 {
-	int c;
+	int c, fd;
 	char **cmd = NULL;
 	int cmd_count = 0;
 	char *display = NULL;
@@ -287,7 +287,9 @@ main(int argc, char *argv[])
 	set_close_on_exec(ConnectionNumber(dpy));
 
 	/* forked commands should not get X console tty as their stdin */
-	dup2(open("/dev/null", O_RDONLY), STDIN_FILENO);
+	fd = open("/dev/null", O_RDONLY);
+	dup2(fd, STDIN_FILENO);
+	close(fd);
 
 	/* Set our own specific Atoms. */
 	rp_selection = XInternAtom(dpy, "RP_SELECTION", False);


### PR DESCRIPTION
There was a file descriptor leak introduced by previous commit 1d025fb4 which opens `/dev/null` and duplicates it onto the standard input descriptor so child processes do not inherit the tty where X started as their standard input.  This PR is a trivial patch to close the leak.

It was noticed like so:
```
 $ lvm
File descriptor 4 (/dev/null) leaked on lvm invocation. Parent PID 470913: /bin/bash
  WARNING: Running as a non-root user. Functionality may be unavailable.
lvm> ^D

 $ lsa /proc/$$/fd
lrwx------ 1 1001 666 64 20240909004440 0 -> /dev/pts/20
lrwx------ 1 1001 666 64 20240909004440 1 -> /dev/pts/20
lrwx------ 1 1001 666 64 20240909004440 2 -> /dev/pts/20
lrwx------ 1 1001 666 64 20240909004440 255 -> /dev/pts/20
lr-x------ 1 1001 666 64 20240909004440 4 -> /dev/null
```

the fd 4 is the one from the `open("/dev/null")` call held by sdorfehs:
```
 $ lsa /proc/`pgrep -P1 sdorfehs`/fd
lr-x------ 1 1001 666 64 20240909180255 0 -> /dev/null
l-wx------ 1 1001 666 64 20240909180255 1 -> pipe:[11682]
l-wx------ 1 1001 666 64 20240909180255 2 -> pipe:[11682]
lrwx------ 1 1001 666 64 20240909180255 3 -> socket:[12584]
lr-x------ 1 1001 666 64 20240909180255 4 -> /dev/null
lr-x------ 1 1001 666 64 20240909180255 5 -> /home/scott/.config/sdorfehs/bar|
lrwx------ 1 1001 666 64 20240909180255 6 -> socket:[12630]
```

The patch closes the `/dev/null` after duplicating, so it won't propagate.
